### PR TITLE
[chore] EC2 배포 시 CloudWatch 로그 연동 설정 추가

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -53,7 +53,7 @@ jobs:
               --log-opt awslogs-region=ap-northeast-2 \
               --log-opt awslogs-group=/aws/ec2/jjigeojulge-server \
               --log-opt awslogs-create-group=true \
-              --log-opt awslogs-stream-prefix=backend
+              --log-opt awslogs-stream-prefix=backend \
               -p 8080:8080 \
               ${{ secrets.DOCKER_USERNAME }}/jjigeojulge-server:latest
 


### PR DESCRIPTION
## 🔗 관련 Jira 이슈
- DND3-32
- DND3-35

## 작업 사항
EC2 내부 컨테이너의 로그 휘발성 문제를 해결하고, 지속적인 모니터링을 위해 AWS CloudWatch 로그 연동 설정을 추가했습니다.

**Github Actions CD 설정 수정 (`backend-cd.yml`)**
- `docker run` 명령어에 `awslogs` 드라이버 옵션 4줄 추가
  - **Driver**: `awslogs`
  - **Region**: `ap-northeast-2` (서울)
  - **Log Group**: `/aws/ec2/jjigeojulge-server` (배포 시 자동 생성)
  - **Stream Prefix**: `backend` (로그 식별 용이하도록 접두사 설정)

## 기타
> merge 브랜치를 확인해주세요.

- 이제 EC2에 SSH로 접속하지 않아도 AWS CloudWatch 콘솔에서 실시간 로그 확인이 가능합니다.
- 배포 완료 후 `CloudWatch > Log groups > /aws/ec2/jjigeojulge-server` 경로에서 로그가 쌓이는 것을 확인할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **인프라 운영**
  * EC2 배포 과정에 AWS CloudWatch 로깅 구성이 추가되어 배포된 컨테이너의 로그가 중앙에서 수집·관리되어 모니터링 및 문제 진단이 개선됩니다.

<sub>✏️ Tip: 검토 설정에서 이 고수준 요약을 커스터마이즈할 수 있습니다.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->