### PR TITLE
[fix] 온보딩 과정에서의 닉네임 중복 검사 접근 권한 허용

### DIFF
--- a/src/main/java/com/dnd/jjigeojulge/auth/infra/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/jjigeojulge/auth/infra/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
 					"/api/v1/auth/**",
+					"/api/v1/users/check-nickname",
 					"/health",
 					"/swagger-ui/**",
 					"/v3/api-docs/**",


### PR DESCRIPTION
<!--
제목 규칙
- [feature] 로그인 기능 개선
- [fix] 로그인 오류 수정
- [chore] PR 템플릿 정리
-->

## 🔗 관련 Jira 이슈

## 작업 사항

<!-- 무엇을 왜 변경했는지 간단히 작성해주세요. -->
   - 온보딩 단계에서 accessToken이 없는 신규 사용자가 닉네임 중복 확인을 할 수 있도록
     /api/v1/users/check-nickname 엔드포인트를 permitAll()에 추가했습니다.
   - 인증 헤더 없이 호출 시 401 Unauthorized가 발생하던 문제를 해결하여, 회원가입 전 닉네임 유효성 검사가
     가능하도록 개선했습니다.


## 기타

> merge 브랜치를 확인해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 닉네임 중복 확인 기능을 인증 없이 사용할 수 있도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->